### PR TITLE
chore: Rename `autoSponsor` to `sponsorAndProve`

### DIFF
--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -21,7 +21,7 @@ export type SponsoredAuthInputs =
       };
     }
   | {
-      autoSponsor: {
+      sponsorAndProve: {
         userAuthInputs: AuthInputs;
       };
     };


### PR DESCRIPTION
Rename `autoSponsor` to `sponsorAndProve`