### PR TITLE
feat: output root support

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -1,0 +1,19 @@
+import { encodePacked, keccak256 } from "viem";
+import { L2BlockClient, L2BlockRef } from "./types";
+import { Hash } from "./types/primitives";
+
+export function createL2BlockClient(block: L2BlockRef): L2BlockClient {
+  const outputRoot = (): Hash => {
+    return keccak256(
+      encodePacked(
+        ["bytes32", "bytes32", "bytes32"],
+        [block.stateRoot, block.withdrawalsRoot, block.hash],
+      ),
+    );
+  };
+
+  return {
+    outputRoot,
+    ...block,
+  };
+}

--- a/src/client/nodeClient.ts
+++ b/src/client/nodeClient.ts
@@ -8,7 +8,7 @@ import {
   GetBalanceResponse,
   GetBlockByHashResponse,
   GetBlockByNumberResponse,
-  GetBlockNumberByStateRootResponse,
+  GetBlockNumberByOutputRootResponse,
   GetProofResponse,
   GetStateAtResponse,
   GetTransactionByHashResponse,
@@ -149,14 +149,14 @@ export function createNodeClient(config: NodeClientConfig): NodeClient {
     return formatGetTransactionReceiptResponse(res);
   };
 
-  const getBlockNumberByStateRoot = async ({
-    stateRoot,
+  const getBlockNumberByOutputRoot = async ({
+    outputRoot,
   }: {
-    stateRoot: Hash;
-  }): Promise<GetBlockNumberByStateRootResponse> => {
+    outputRoot: Hash;
+  }): Promise<GetBlockNumberByOutputRootResponse> => {
     const res = await client.request({
-      method: "keystore_getBlockNumberByStateRoot",
-      params: [stateRoot],
+      method: "keystore_getBlockNumberByOutputRoot",
+      params: [outputRoot],
     });
     return formatGetBlockNumberByStateRootResponse(res);
   };
@@ -244,7 +244,7 @@ export function createNodeClient(config: NodeClientConfig): NodeClient {
     call,
     getTransactionByHash,
     getTransactionReceipt,
-    getBlockNumberByStateRoot,
+    getBlockNumberByOutputRoot,
     getBlockByNumber,
     getBlockByHash,
     waitForTransactionReceipt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from "./signature-provers";
 export * from "./types";
 export * from "./transaction";
 export * from "./l1-initiation";
+export * from "./block";

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -48,3 +48,9 @@ export type L2BlockRef = {
   source?: Byte;
   transactions?: TransactionOrHash[];
 };
+
+export interface BlockAction {
+  outputRoot: () => Hash;
+}
+
+export interface L2BlockClient extends L2BlockRef, BlockAction {}

--- a/src/types/client/node.ts
+++ b/src/types/client/node.ts
@@ -4,7 +4,7 @@ import {
   GetBalanceResponse,
   GetBlockByHashResponse,
   GetBlockByNumberResponse,
-  GetBlockNumberByStateRootResponse,
+  GetBlockNumberByOutputRootResponse,
   GetProofResponse,
   GetStateAtResponse,
   GetTransactionByHashResponse,
@@ -67,11 +67,11 @@ export interface NodeClient {
 
   getTransactionReceipt: ({ hash }: { hash: Hash }) => Promise<GetTransactionReceiptResponse>;
 
-  getBlockNumberByStateRoot: ({
-    stateRoot,
+  getBlockNumberByOutputRoot: ({
+    outputRoot,
   }: {
-    stateRoot: Hash;
-  }) => Promise<GetBlockNumberByStateRootResponse>;
+    outputRoot: Hash;
+  }) => Promise<GetBlockNumberByOutputRootResponse>;
 
   getBlockByNumber: ({
     block,

--- a/src/types/formatters/response.ts
+++ b/src/types/formatters/response.ts
@@ -7,7 +7,7 @@ import {
   GetBalanceResponse,
   GetBlockByHashResponse,
   GetBlockByNumberResponse,
-  GetBlockNumberByStateRootResponse,
+  GetBlockNumberByOutputRootResponse,
   GetBlockTransactionCountByHashResponse,
   GetBlockTransactionCountByNumberResponse,
   GetStateAtResponse,
@@ -28,7 +28,7 @@ import {
   GetBalanceResponseRpc,
   GetBlockByHashResponseRpc,
   GetBlockByNumberResponseRpc,
-  GetBlockNumberByStateRootResponseRpc,
+  GetBlockNumberByOutputRootResponseRpc,
   GetBlockTransactionCountByHashResponseRpc,
   GetBlockTransactionCountByNumberResponseRpc,
   GetStateAtResponseRpc,
@@ -161,8 +161,8 @@ export function formatGetTransactionReceiptResponse(
 }
 
 export function formatGetBlockNumberByStateRootResponse(
-  rpcObj: GetBlockNumberByStateRootResponseRpc,
-): GetBlockNumberByStateRootResponse {
+  rpcObj: GetBlockNumberByOutputRootResponseRpc,
+): GetBlockNumberByOutputRootResponse {
   return BigInt(rpcObj);
 }
 

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -88,7 +88,7 @@ export type GetTransactionReceiptResponse = {
   amount?: Quantity;
 };
 
-export type GetBlockNumberByStateRootResponse = Quantity;
+export type GetBlockNumberByOutputRootResponse = Quantity;
 export type GasPriceResponse = Quantity;
 export type SendRawTransactionResponse = Hash;
 export type AuthenticateTransactionResponse = Hash;

--- a/src/types/rpc/response.ts
+++ b/src/types/rpc/response.ts
@@ -72,7 +72,7 @@ export type GetTransactionReceiptResponseRpc = {
   amount?: HexQuantity;
 };
 
-export type GetBlockNumberByStateRootResponseRpc = HexQuantity;
+export type GetBlockNumberByOutputRootResponseRpc = HexQuantity;
 
 export type GasPriceResponseRpc = HexQuantity;
 

--- a/test/client/sharedClientTests.ts
+++ b/test/client/sharedClientTests.ts
@@ -1,6 +1,7 @@
 import {
   BlockTag,
   BlockTransactionsKind,
+  createL2BlockClient,
   createUpdateTransactionClient,
   GetTransactionReceiptResponse,
   NodeClient,
@@ -145,12 +146,15 @@ export function runNodeClientTests(createClient: () => NodeClient) {
       await expect(client.getTransactionReceipt({ hash: NON_EXISTENT_TX_HASH })).rejects.toThrow();
     });
 
-    test("keystore_getBlockNumberByStateRoot", async () => {
+    test("keystore_getBlockNumberByOutputRoot", async () => {
       const block = await client.getBlockByNumber({
         block: BlockTag.Latest,
         txKind: BlockTransactionsKind.Hashes,
       });
-      const blockNumber = await client.getBlockNumberByStateRoot({ stateRoot: block.stateRoot });
+      const blockClient = createL2BlockClient(block);
+      const blockNumber = await client.getBlockNumberByOutputRoot({
+        outputRoot: blockClient.outputRoot(),
+      });
       expect(blockNumber).toBe(block.number);
     });
 


### PR DESCRIPTION
- replace `getBlockNumberByStateRoot` by `getBlockNumberByOutputRoot`
- calc output root for l2 blocks

Note: unit tests fail because lack of support on prod backend. I have tested them locally and they work.

Closes INT-4020