### PR TITLE
fix: remove `chain` type annotation from L1 actions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,4 +9,10 @@ export default [
   pluginJs.configs.recommended,
   eslintConfigPrettier,
   ...tseslint.configs.recommended,
+  {
+    files: ["**/*.d.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];

--- a/examples/deposit-withdraw/src/index.ts
+++ b/examples/deposit-withdraw/src/index.ts
@@ -93,6 +93,8 @@ async function main() {
   const [depositL2TxHash] = getL2TransactionHashes(l1TxReceipt);
   console.log("Deposit transaction hash:", depositL2TxHash);
 
+  console.log("Waiting for deposit transaction receipt on Keystore (L2)");
+
   const l2TxReceipt = await l2Client.waitForTransactionReceipt({ hash: depositL2TxHash });
   console.log("Deposit transaction receipt:", l2TxReceipt);
 

--- a/src/l1-initiation/publicL1.ts
+++ b/src/l1-initiation/publicL1.ts
@@ -1,4 +1,3 @@
-import { Account, Chain, Client, Transport } from "viem";
 import AxiomKeystoreRollupAbi from "./abi/AxiomKeystoreRollup.json";
 import { TransactionType } from "@/types";
 import { BridgeAddressParameter } from "./common";
@@ -17,11 +16,8 @@ export type PublicActionsL1 = {
   l1InitiatedFee: (parameters: L1InitiatedFeeParameters) => Promise<L1InitiatedFeeReturnType>;
 };
 
-async function l1BatchCount<
-  chain extends Chain | undefined = Chain | undefined,
-  account extends Account | undefined = Account | undefined,
->(
-  client: Client<Transport, chain, account>,
+async function l1BatchCount(
+  client: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   parameters: L1BatchCountParameters,
 ): Promise<L1BatchCountReturnType> {
   const { bridgeAddress } = parameters;
@@ -33,11 +29,8 @@ async function l1BatchCount<
   })) as bigint;
 }
 
-async function l1InitiatedFee<
-  chain extends Chain | undefined = Chain | undefined,
-  account extends Account | undefined = Account | undefined,
->(
-  client: Client<Transport, chain, account>,
+async function l1InitiatedFee(
+  client: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   parameters: L1InitiatedFeeParameters,
 ): Promise<L1InitiatedFeeReturnType> {
   const { bridgeAddress, txType } = parameters;
@@ -50,12 +43,8 @@ async function l1InitiatedFee<
 }
 
 export function publicActionsL1() {
-  return <
-    transport extends Transport,
-    chain extends Chain | undefined = Chain | undefined,
-    account extends Account | undefined = Account | undefined,
-  >(
-    client: Client<transport, chain, account>,
+  return (
+    client: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   ): PublicActionsL1 => {
     return {
       l1BatchCount: (parameters) => l1BatchCount(client, parameters),

--- a/src/l1-initiation/walletL1.ts
+++ b/src/l1-initiation/walletL1.ts
@@ -5,8 +5,6 @@ import {
   Hash,
   TransactionType,
 } from "@/types";
-import { Account, Chain, Client, Transport } from "viem";
-import { PublicActionsL1 } from "./publicL1";
 import AxiomKeystoreRollupAbi from "./abi/AxiomKeystoreRollup.json";
 import { BridgeAddressParameter } from "./common";
 import { writeContract } from "viem/actions";
@@ -84,12 +82,8 @@ async function finalizeWithdrawal(
 }
 
 export function walletActionsL1() {
-  return <
-    transport extends Transport,
-    chain extends Chain | undefined = Chain | undefined,
-    account extends Account | undefined = Account | undefined,
-  >(
-    client: Client<transport, chain, account> & PublicActionsL1,
+  return (
+    client: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   ): WalletActionsL1 => {
     return {
       initiateL1Transaction: (parameters) => initiateL1Transaction(client, parameters),


### PR DESCRIPTION
Fixes the incompatible types error in external imports.