### PR TITLE
feat: transaction request

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ The SDK supports all transaction types of the keystore rollup, including `Deposi
 
 #### Deposit
 
-To create a client for the `Deposit` transaction type, you can use the `createDepositTransactionClient` function. You'll need to provide the recipient `keystoreAddress` and the deposit `amt`.
+To create a client for the `Deposit` transaction type, you can use the `createDepositTransactionRequestClient` function. You'll need to provide the recipient `keystoreAddress` and the deposit `amt`.
 
 ```typescript
-const depositTx = await createDepositTransactionClient({
+const depositTx = await createDepositTransactionRequestClient({
   keystoreAddress: userAcct.address,
   amt: parseEther("0.01"),
 });
@@ -82,10 +82,10 @@ const depositTx = await createDepositTransactionClient({
 
 #### Withdraw
 
-To create a client for the `Withdraw` transaction type, you can use the `createWithdrawTransactionClient` function. You'll need to provide the withdrawal `amt`, the recipient address `to` on L1, the `userAcct` (the keystore account initiating the withdrawal).
+To create a client for the `Withdraw` transaction type, you can use the `createWithdrawTransactionRequestClient` function. You'll need to provide the withdrawal `amt`, the recipient address `to` on L1, the `userAcct` (the keystore account initiating the withdrawal).
 
 ```typescript
-const withdrawTx = await createWithdrawTransactionClient({
+const withdrawTx = await createWithdrawTransactionRequestClient({
   amt: parseEther("0.005"),
   to: account.address,
   userAcct,
@@ -94,7 +94,7 @@ const withdrawTx = await createWithdrawTransactionClient({
 
 #### Update
 
-To create a client for the `Update` transaction type, you can use the `createUpdateTransactionClient` function. In addition to the user keystore account we created earlier, we'll be providing an optional Sponsor Account that will be sponsoring the `Update` transaction on the keystore rollup.
+To create a client for the `Update` transaction type, you can use the `createUpdateTransactionRequestClient` function. In addition to the user keystore account we created earlier, we'll be providing an optional Sponsor Account that will be sponsoring the `Update` transaction on the keystore rollup.
 
 ```typescript
 const sponsorAcct = initAccountFromAddress({
@@ -103,7 +103,7 @@ const sponsorAcct = initAccountFromAddress({
   vkey: mOfNEcdsaClient.vkey,
   nodeClient,
 });
-const updateTx = await createUpdateTransactionClient({
+const updateTx = await createUpdateTransactionRequestClient({
   newUserData: keyData,
   newUserVkey: mOfNEcdsaClient.vkey,
   userAcct,
@@ -136,7 +136,7 @@ const sponsorAuthInputs = mOfNEcdsaClient.makeAuthInputs({
 
 // Send authentication data to the signature prover
 const authHash = await mOfNEcdsaClient.authenticateSponsoredTransaction({
-  transaction: updateTx.toBytes(),
+  transaction: updateTx.rawSequencerTransaction(),
   sponsoredAuthInputs: {
     userAuthInputs,
     sponsorAuthInputs,
@@ -180,7 +180,7 @@ const l1Client = createWalletClient({
   .extend(walletActionsL1());
 ```
 
-Next, prepare the L1 transaction data using a specific transaction client (e.g., `createDepositTransactionClient`). Then, send this transaction to the L1 bridge contract using the `initiateL1Transaction` method on your extended L1 client.
+Next, prepare the L1 transaction data using a specific transaction client (e.g., `createDepositTransactionRequestClient`). Then, send this transaction to the L1 bridge contract using the `initiateL1Transaction` method on your extended L1 client.
 
 Once the L1 transaction is confirmed, retrieve its receipt. From this L1 receipt, you can extract the corresponding L2 transaction hash using `getL2TransactionHashes`. Finally, use a `SequencerClient` (or `NodeClient`) to wait for the L2 transaction to be processed and get its receipt.
 
@@ -188,7 +188,7 @@ Once the L1 transaction is confirmed, retrieve its receipt. From this L1 receipt
 // Send the deposit transaction to L1
 const l1TxHash = await l1Client.initiateL1Transaction({
   bridgeAddress: config.bridgeAddress,
-  txClient: depositTx,
+  txRequestClient: depositTx,
 });
 console.log("L1 transaction hash:", l1TxHash);
 

--- a/examples/deposit-withdraw/src/index.ts
+++ b/examples/deposit-withdraw/src/index.ts
@@ -6,11 +6,11 @@ import {
   MOfNEcdsaKeyDataFields,
   MOfNEcdsaAuthDataFields,
   MOfNEcdsaAuthInputs,
-  createDepositTransactionClient,
+  createDepositTransactionRequestClient,
   publicActionsL1,
   walletActionsL1,
   getL2TransactionHashes,
-  createWithdrawTransactionClient,
+  createWithdrawTransactionRequestClient,
   SEQUENCER_URL,
   M_OF_N_ECDSA_SIG_PROVER_URL,
   BRIDGE_ADDRESS,
@@ -76,15 +76,15 @@ async function main() {
   console.log("User account initialized:", userAcct);
 
   // Create a deposit transaction
-  const depositTx = await createDepositTransactionClient({
+  const depositTx = await createDepositTransactionRequestClient({
     keystoreAddress: userAcct.address,
     amt: parseEther("0.01"),
   });
 
   // Send the deposit transaction to L1
   const depositL1TxHash = await l1Client.initiateL1Transaction({
-    bridgeAddress: config.bridgeAddress,
-    txClient: depositTx,
+    bridgeAddress: config.bridgeAddress as `0x${string}`,
+    txRequestClient: depositTx,
   });
   console.log("L1 transaction hash:", depositL1TxHash);
 
@@ -99,7 +99,7 @@ async function main() {
   console.log("Deposit transaction receipt:", l2TxReceipt);
 
   // Create a withdraw transaction
-  const withdrawTx = await createWithdrawTransactionClient({
+  const withdrawTx = await createWithdrawTransactionRequestClient({
     amt: parseEther("0.005"),
     to: account.address,
     userAcct,
@@ -117,7 +117,7 @@ async function main() {
   });
 
   const authHash = await mOfNEcdsaClient.authenticateTransaction({
-    transaction: withdrawTx.toBytes(),
+    transaction: withdrawTx.rawSequencerTransaction(),
     authInputs: userAuthInputs,
   });
   const authenticatedTx = await mOfNEcdsaClient.waitForAuthentication({ hash: authHash });
@@ -136,7 +136,7 @@ async function main() {
     transactionHash: withdrawTxHash,
   });
   const finalizeWithdrawalL1TxHash = await l1Client.finalizeWithdrawal({
-    bridgeAddress: config.bridgeAddress,
+    bridgeAddress: config.bridgeAddress as `0x${string}`,
     ...finalizationArgs,
   });
   console.log("Withdrawal finalized on L1. L1 transaction hash:", finalizeWithdrawalL1TxHash);

--- a/examples/update/src/index.ts
+++ b/examples/update/src/index.ts
@@ -1,7 +1,7 @@
 import {
   createSignatureProverClient,
   initAccountCounterfactual,
-  createUpdateTransactionClient,
+  createUpdateTransactionRequestClient,
   createSequencerClient,
   initAccountFromAddress,
   SEQUENCER_URL,
@@ -80,7 +80,7 @@ async function main() {
 
   // Create a client to handle the Update transaction type, which is used to update the user
   // keystore account's data and vkey.
-  const updateTx = await createUpdateTransactionClient({
+  const updateTx = await createUpdateTransactionRequestClient({
     newUserData: keyData,
     newUserVkey: mOfNEcdsaClient.vkey,
     userAcct,
@@ -102,7 +102,7 @@ async function main() {
   });
 
   const authHash = await mOfNEcdsaClient.authenticateSponsoredTransaction({
-    transaction: updateTx.toBytes(),
+    transaction: updateTx.rawSequencerTransaction(),
     sponsoredAuthInputs: {
       userAuthInputs,
       sponsorAuthInputs,

--- a/src/client/nodeClient.ts
+++ b/src/client/nodeClient.ts
@@ -1,5 +1,5 @@
 import { DEFAULTS } from "@/config";
-import { createWithdrawTransactionClient } from "@/transaction";
+import { createWithdrawTransactionRequestClient } from "@/transaction";
 import {
   BatchTag,
   BatchTagOrIndex,
@@ -303,11 +303,11 @@ export function createNodeClient(config: NodeClientConfig): NodeClient {
       txKind: BlockTransactionsKind.Hashes,
     });
 
-    const txClient = await (async () => {
+    const txRequestClient = await (async () => {
       const tx = await getTransactionByHash({ hash: transactionHash });
       switch (tx.type) {
         case TransactionType.Withdraw:
-          return createWithdrawTransactionClient({ ...tx });
+          return createWithdrawTransactionRequestClient({ ...tx });
         case TransactionType.Deposit:
         case TransactionType.Update:
           throw new Error(
@@ -317,7 +317,7 @@ export function createNodeClient(config: NodeClientConfig): NodeClient {
     })();
 
     const withdrawalProof = await getWithdrawalProof({
-      withdrawalHash: txClient.withdrawalHash(),
+      withdrawalHash: txRequestClient.withdrawalHash(),
       block: block.number,
     });
 

--- a/src/l1-initiation/walletL1.ts
+++ b/src/l1-initiation/walletL1.ts
@@ -1,6 +1,6 @@
 import {
   BaseTransactionAction,
-  DepositTransactionClient,
+  DepositTransactionRequestClient,
   FinalizeWithdrawalArgs,
   Hash,
   TransactionType,
@@ -12,7 +12,7 @@ import { writeContract } from "viem/actions";
 const abi = AxiomKeystoreRollupAbi.abi;
 
 export type InitiateL1TransactionParameters = BridgeAddressParameter & {
-  txClient: BaseTransactionAction;
+  txRequestClient: BaseTransactionAction;
 };
 
 export type InitiateL1TransactionReturnType = Hash;
@@ -35,14 +35,14 @@ async function initiateL1Transaction(
   client: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   parameters: InitiateL1TransactionParameters,
 ): Promise<InitiateL1TransactionReturnType> {
-  const { bridgeAddress, txClient } = parameters;
+  const { bridgeAddress, txRequestClient } = parameters;
 
   const value = await (async () => {
-    switch (txClient.txType) {
+    switch (txRequestClient.txType) {
       case TransactionType.Deposit:
         return (
           (await client.l1InitiatedFee({ bridgeAddress, txType: TransactionType.Deposit })) +
-          (txClient as DepositTransactionClient).amt
+          (txRequestClient as DepositTransactionRequestClient).amt
         );
       case TransactionType.Withdraw:
         return client.l1InitiatedFee({ bridgeAddress, txType: TransactionType.Withdraw });
@@ -59,7 +59,7 @@ async function initiateL1Transaction(
     address: bridgeAddress,
     abi,
     functionName: "initiateL1Transaction",
-    args: [txClient.l1InitiatedTransaction()],
+    args: [txRequestClient.l1InitiatedTransaction()],
     value,
   });
 }

--- a/src/transaction/deposit.ts
+++ b/src/transaction/deposit.ts
@@ -1,32 +1,16 @@
 import {
-  Data,
-  DepositTransactionClient,
+  DepositTransactionRequestClient,
   DepositTransactionInputs,
-  Hash,
   L1InitiatedTransactionSol,
   TransactionType,
 } from "@/types";
-import { encodePacked, keccak256, numberToHex, pad } from "viem";
 
-export async function createDepositTransactionClient(
+export async function createDepositTransactionRequestClient(
   tx: DepositTransactionInputs,
-): Promise<DepositTransactionClient> {
-  const l1InitiatedNonce = tx.l1InitiatedNonce
-    ? numberToHex(tx.l1InitiatedNonce, { size: 32 })
-    : pad("0x", { size: 32 });
-
+): Promise<DepositTransactionRequestClient> {
   const amt = tx.amt;
 
   const keystoreAddress = tx.keystoreAddress;
-
-  const toBytes = (): Data => {
-    return encodePacked(
-      ["bytes1", "bytes", "uint256", "bytes"],
-      [TransactionType.Deposit, l1InitiatedNonce, amt, keystoreAddress],
-    );
-  };
-
-  const txHash = (): Hash => keccak256(toBytes());
 
   const l1InitiatedTransaction = (): L1InitiatedTransactionSol => {
     return {
@@ -37,11 +21,8 @@ export async function createDepositTransactionClient(
 
   return {
     txType: TransactionType.Deposit,
-    l1InitiatedNonce: tx.l1InitiatedNonce,
     amt,
     keystoreAddress,
-    toBytes,
-    txHash,
     l1InitiatedTransaction,
   };
 }

--- a/src/types/transaction/base.ts
+++ b/src/types/transaction/base.ts
@@ -24,9 +24,11 @@ export type BaseTransaction = {
 
 export interface BaseTransactionAction {
   txType: TransactionType;
-  toBytes: () => Data;
-  txHash: () => Hash;
   l1InitiatedTransaction: () => L1InitiatedTransactionSol;
+}
+
+export interface SequencerTransactionAction {
+  rawSequencerTransaction: () => Data;
 }
 
 export interface WithdrawTransactionAction {

--- a/src/types/transaction/deposit.ts
+++ b/src/types/transaction/deposit.ts
@@ -11,9 +11,10 @@ export type DepositTransaction = BaseTransaction & {
 };
 
 export interface DepositTransactionInputs {
-  l1InitiatedNonce?: bigint;
   amt: bigint;
   keystoreAddress: KeystoreAddress;
 }
 
-export interface DepositTransactionClient extends DepositTransactionInputs, BaseTransactionAction {}
+export interface DepositTransactionRequestClient
+  extends DepositTransactionInputs,
+    BaseTransactionAction {}

--- a/src/types/transaction/update.ts
+++ b/src/types/transaction/update.ts
@@ -1,6 +1,11 @@
 import { KeystoreAccount } from "../keystoreAccount";
 import { Data, Quantity } from "../primitives";
-import { BaseTransaction, BaseTransactionAction, SignableTransactionAction } from "./base";
+import {
+  BaseTransaction,
+  BaseTransactionAction,
+  SequencerTransactionAction,
+  SignableTransactionAction,
+} from "./base";
 
 /**
  * An update transaction (type = "0x02").
@@ -39,13 +44,12 @@ export interface UpdateTransactionInputs {
   sponsorAcct?: KeystoreAccount;
   userProof?: Data;
   sponsorProof?: Data;
-  l1InitiatedNonce?: bigint;
-  isL1Initiated?: boolean;
   nodeClientUrl?: string;
   sequencerClientUrl?: string;
 }
 
-export interface UpdateTransactionClient
+export interface UpdateTransactionRequestClient
   extends UpdateTransactionInputs,
     SignableTransactionAction,
-    BaseTransactionAction {}
+    BaseTransactionAction,
+    SequencerTransactionAction {}

--- a/src/types/transaction/withdraw.ts
+++ b/src/types/transaction/withdraw.ts
@@ -3,6 +3,7 @@ import { L1Address, Data, Quantity } from "../primitives";
 import {
   BaseTransaction,
   BaseTransactionAction,
+  SequencerTransactionAction,
   SignableTransactionAction,
   WithdrawTransactionAction,
 } from "./base";
@@ -34,14 +35,13 @@ export interface WithdrawTransactionInputs {
   amt: bigint;
   userAcct: KeystoreAccount;
   userProof?: Data;
-  isL1Initiated?: boolean;
-  l1InitiatedNonce?: bigint;
   nodeClientUrl?: string;
   sequencerClientUrl?: string;
 }
 
-export interface WithdrawTransactionClient
+export interface WithdrawTransactionRequestClient
   extends WithdrawTransactionInputs,
     SignableTransactionAction,
     BaseTransactionAction,
+    SequencerTransactionAction,
     WithdrawTransactionAction {}

--- a/test/client/sequencerClient.test.ts
+++ b/test/client/sequencerClient.test.ts
@@ -1,7 +1,7 @@
 import {
   BlockTag,
   createSequencerClient,
-  createUpdateTransactionClient,
+  createUpdateTransactionRequestClient,
   SequencerClient,
   SEQUENCER_URL,
 } from "../../src";
@@ -28,15 +28,17 @@ describe("Keystore Sequencer Client", () => {
     });
 
     test("keystore_estimateGas", async () => {
-      const tx = await createUpdateTransactionClient(TEST_TX_REQ);
-      const gasEstimate = await sequencerClient.estimateGas({ txData: tx.toBytes() });
+      const tx = await createUpdateTransactionRequestClient(TEST_TX_REQ);
+      const gasEstimate = await sequencerClient.estimateGas({
+        txData: tx.rawSequencerTransaction(),
+      });
       expect(typeof gasEstimate).toBe("bigint");
     });
 
     test("keystore_estimateL1DataFee", async () => {
-      const tx = await createUpdateTransactionClient(TEST_TX_REQ);
+      const tx = await createUpdateTransactionRequestClient(TEST_TX_REQ);
       const l1FeeEstimate = await sequencerClient.estimateL1DataFee({
-        txData: tx.toBytes(),
+        txData: tx.rawSequencerTransaction(),
         block: BlockTag.Latest,
       });
       expect(typeof l1FeeEstimate).toBe("bigint");

--- a/test/client/sharedClientTests.ts
+++ b/test/client/sharedClientTests.ts
@@ -2,7 +2,7 @@ import {
   BlockTag,
   BlockTransactionsKind,
   createL2BlockClient,
-  createUpdateTransactionClient,
+  createUpdateTransactionRequestClient,
   GetTransactionReceiptResponse,
   NodeClient,
   TransactionStatus,
@@ -108,9 +108,9 @@ export function runNodeClientTests(createClient: () => NodeClient) {
     });
 
     test("keystore_call", async () => {
-      const tx = await createUpdateTransactionClient(TEST_TX_REQ);
+      const tx = await createUpdateTransactionRequestClient(TEST_TX_REQ);
       await client.call({
-        transaction: tx.toBytes(),
+        transaction: tx.rawSequencerTransaction(),
         block: BlockTag.Latest,
       });
     });

--- a/test/transaction/deposit.test.ts
+++ b/test/transaction/deposit.test.ts
@@ -1,13 +1,13 @@
 import { pad } from "viem";
 import {
-  createDepositTransactionClient,
+  createDepositTransactionRequestClient,
   createNodeClient,
-  DepositTransactionClient,
+  DepositTransactionRequestClient,
   initAccountCounterfactual,
 } from "../../src";
 
 describe("Deposit Transaction", () => {
-  let depositTx: DepositTransactionClient;
+  let depositTx: DepositTransactionRequestClient;
 
   beforeEach(async () => {
     const nodeClient = createNodeClient({
@@ -19,22 +19,16 @@ describe("Deposit Transaction", () => {
       vkey: "0x1234abcd",
       nodeClient,
     });
-    depositTx = await createDepositTransactionClient({
+    depositTx = await createDepositTransactionRequestClient({
       keystoreAddress: userAcct.address,
       amt: 20000n,
-      l1InitiatedNonce: 0n,
     });
   });
 
-  test("Get Transaction Bytes", () => {
-    const txBytes = depositTx.toBytes();
-    expect(txBytes).toEqual(
-      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004e20dafd7a698501896eefef0a3893d88ca07bc07a09888ee54ab60a4b079baa2179",
+  test("Get Transaction Request Bytes", () => {
+    const txRequest = depositTx.l1InitiatedTransaction();
+    expect(txRequest.data).toEqual(
+      "0xdafd7a698501896eefef0a3893d88ca07bc07a09888ee54ab60a4b079baa2179",
     );
-  });
-
-  test("Get Transaction Hash", () => {
-    const txHash = depositTx.txHash();
-    expect(txHash).toEqual("0x690b3dca835c2e235f44a4268f57f321b6b12777d66ecc005f52b3826e1805d4");
   });
 });

--- a/test/transaction/update.test.ts
+++ b/test/transaction/update.test.ts
@@ -1,10 +1,10 @@
 import { pad } from "viem";
 import {
   createNodeClient,
-  createUpdateTransactionClient,
+  createUpdateTransactionRequestClient,
   initAccountCounterfactual,
   initAccountFromAddress,
-  UpdateTransactionClient,
+  UpdateTransactionRequestClient,
 } from "../../src";
 import {
   AXIOM_SPONSOR_ADDRESS,
@@ -14,7 +14,7 @@ import {
 } from "../testUtils";
 
 describe("Update Transaction", () => {
-  let updateTx: UpdateTransactionClient;
+  let updateTx: UpdateTransactionRequestClient;
 
   beforeEach(async () => {
     const nodeClient = createNodeClient({
@@ -32,7 +32,7 @@ describe("Update Transaction", () => {
       vkey: M_OF_N_ECDSA_VKEY,
       nodeClient,
     });
-    updateTx = await createUpdateTransactionClient({
+    updateTx = await createUpdateTransactionRequestClient({
       nonce: 0n,
       feePerGas: 10000000n,
       newUserData: "0x1234",
@@ -43,7 +43,7 @@ describe("Update Transaction", () => {
   });
 
   test("Get Transaction Bytes", () => {
-    const txBytes = updateTx.toBytes();
+    const txBytes = updateTx.rawSequencerTransaction();
     expect(txBytes).toEqual(
       "0x0200f9022080a00000000000000000000000000000000000000000000000000000000000989680821234821234a0dafd7a698501896eefef0a3893d88ca07bc07a09888ee54ab60a4b079baa2179a00000000000000000000000000000000000000000000000001234567890abababa00000000000000000000000000000000000000000000000000000001234567890841234abcd80b9018bf90188a0b5ce21832ca3bbf53de610c6dda13d6a735b0a8ea3422aeaab678a01e298269da00000000000000000000000000000000000000000000000000000000000000000a0ecf85bc51a8b47c545dad1a47e868276d0a92b7cf2716033ce77d385a6b67c4bb9012201010000001001000100010100000100000000000000000000000000000000009171ded76cb8d446b69cb901fe413fe380886240549feb11014fec000a7eb1280750a550988ceaef9a37f6794af0d9bf472445bc9dfacf89b9f4a6130c2b0eb42ef05dfd54c6d765973c1b3e0c15885e1307bedc893a3474103a065e7a032d04078f64fde979db4eea6692dbde7d161c3e6c3ae99f2e7cf9c58229f8d1a5bb97056fb20596873754a862cbe247b25315399d7be7a8bfe72942564c469d6a95e141a2f3c0bb526ad5ded741e9c10d6920cd28a10f108b0d1f2b22688b67a32c4055f6d42ed1d1c3eb767c513d8aa832c470b29a9dc7afb33fdcfeda198b820f724d13a24c6d1123d95b1124cf08c4aaf9531dd819011b9a13b6151d5ab83225fe451780",
     );
@@ -104,11 +104,6 @@ describe("Update Transaction", () => {
         ],
       },
     });
-  });
-
-  test("Get Transaction Hash", () => {
-    const txHash = updateTx.txHash();
-    expect(txHash).toEqual("0xadbd5467d453ed746a765d284af3fb1877896cfd5522bee89ba23c77e7694d3e");
   });
 
   test("Get User Message Hash", () => {

--- a/test/transaction/withdraw.test.ts
+++ b/test/transaction/withdraw.test.ts
@@ -1,14 +1,14 @@
 import { pad } from "viem";
 import {
   createNodeClient,
-  createWithdrawTransactionClient,
+  createWithdrawTransactionRequestClient,
   initAccountCounterfactual,
-  WithdrawTransactionClient,
+  WithdrawTransactionRequestClient,
 } from "../../src";
 import { TEST_ACCOUNTS } from "../testUtils";
 
 describe("Withdraw Transaction", () => {
-  let withdrawTx: WithdrawTransactionClient;
+  let withdrawTx: WithdrawTransactionRequestClient;
 
   beforeEach(async () => {
     const nodeClient = createNodeClient({
@@ -20,7 +20,7 @@ describe("Withdraw Transaction", () => {
       vkey: "0x1234abcd",
       nodeClient,
     });
-    withdrawTx = await createWithdrawTransactionClient({
+    withdrawTx = await createWithdrawTransactionRequestClient({
       nonce: 0n,
       feePerGas: 10000000n,
       to: "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
@@ -30,7 +30,7 @@ describe("Withdraw Transaction", () => {
   });
 
   test("Get Transaction Bytes", () => {
-    const txBytes = withdrawTx.toBytes();
+    const txBytes = withdrawTx.rawSequencerTransaction();
     expect(txBytes).toEqual(
       "0x0100f8a380a0000000000000000000000000000000000000000000000000000000000098968094a5cc3c03994db5b0d9a5eedd10cabab0813678ac824e20a0dafd7a698501896eefef0a3893d88ca07bc07a09888ee54ab60a4b079baa2179a00000000000000000000000000000000000000000000000001234567890abababa00000000000000000000000000000000000000000000000000000001234567890841234abcd80",
     );
@@ -91,11 +91,6 @@ describe("Withdraw Transaction", () => {
         ],
       },
     });
-  });
-
-  test("Get Transaction Hash", () => {
-    const txHash = withdrawTx.txHash();
-    expect(txHash).toEqual("0x2b2b9c969e63403d174e0ecec6fea2c77228c694a7d5680492f1f1958b9a9f81");
   });
 
   test("Get User Message Hash", () => {


### PR DESCRIPTION
- Gets rid of `txHash()` from the transaction clients
- Turned `toBytes()` into `rawSequencerTransaction()` and just hardcodes `isL1Transaction = false` and `l1InitiatedNonce = "0x"`
- Removed `isL1Transaction` and `l1InitiatedNonce` from `_TransactionInputs`

To send a sequencer tx, raw bytes can be accessed with `.rawSequencerTransaction()`. To send an l1 initiated transaction, the `initiateL1Transaction()` function is still used. But transaction clients no longer have any awareness of `isL1Transaction`, `l1InitiatedNonce`, or `txHash()`.

Closes INT-4208